### PR TITLE
fixed mobile search-bar bug

### DIFF
--- a/src/components/navbar/Navbar.jsx
+++ b/src/components/navbar/Navbar.jsx
@@ -1,5 +1,6 @@
-import React, { useState } from 'react';
-import { RiMenuFill, RiCloseLine,RiMagicLine,RiBarChart2Line,RiFileList3Line,RiUserSettingsLine,RiMoonFill,RiWalletLine,RiSearchLine } from 'react-icons/ri';
+import React, { useEffect, useState } from 'react';
+import { RiMenuFill, RiCloseLine, RiMagicLine, RiBarChart2Line, RiFileList3Line, RiUserSettingsLine, RiMoonFill, RiWalletLine, RiSearchLine } from 'react-icons/ri';
+import { keyframes } from 'styled-components';
 import logo from '../../assets/Logo.jpg';
 import './navbar.css'
 
@@ -9,18 +10,18 @@ const SlideDrawer = (props) => {
     let drawerClasses = 'colorBlue__side-drawer'
     document.body.style.overflow = "visible";
 
-    if(props.show) {
+    if (props.show) {
         drawerClasses = 'colorBlue__side-drawer open'
         document.body.style.overflow = "hidden";
     }
 
-    return(
+    return (
         <div className={drawerClasses}>
             <div className="colorBlue__navbar-menu_container-links">
                 <div className="colorBlue__navbar-menu_wallet">
                     <div className="colorBlue__navbar-menu_links_left">
                         <div className="colorBlue__navbar-menu_links_logo">
-                            <RiWalletLine/>
+                            <RiWalletLine />
                         </div>
                         <a href="#">Wallet</a>
                     </div>
@@ -29,16 +30,16 @@ const SlideDrawer = (props) => {
                 <div className="colorBlue__navbar-menu_profile">
                     <div className="colorBlue__navbar-menu_links_left">
                         <div className="colorBlue__navbar-menu_links_logo">
-                            <RiUserSettingsLine/>
+                            <RiUserSettingsLine />
                         </div>
                         <a href="#">Profile</a>
                     </div>
                     &#62;
-                </div>                
+                </div>
                 <div className="colorBlue__navbar-menu_explore">
                     <div className="colorBlue__navbar-menu_links_left">
                         <div className="colorBlue__navbar-menu_links_logo">
-                            <RiMagicLine/>
+                            <RiMagicLine />
                         </div>
                         <a href="#">Explore</a>
                     </div>
@@ -47,7 +48,7 @@ const SlideDrawer = (props) => {
                 <div className="colorBlue__navbar-menu_stats">
                     <div className="colorBlue__navbar-menu_links_left">
                         <div className="colorBlue__navbar-menu_links_logo">
-                            <RiBarChart2Line/>
+                            <RiBarChart2Line />
                         </div>
                         <a href="#">Stats</a>
                     </div>
@@ -56,7 +57,7 @@ const SlideDrawer = (props) => {
                 <div className="colorBlue__navbar-menu_resources">
                     <div className="colorBlue__navbar-menu_links_left">
                         <div className="colorBlue__navbar-menu_links_logo">
-                            <RiFileList3Line/>
+                            <RiFileList3Line />
                         </div>
                         <a href="#">Resources</a>
                     </div>
@@ -65,7 +66,7 @@ const SlideDrawer = (props) => {
                 <div className="colorBlue__navbar-menu_nightmode">
                     <div className="colorBlue__navbar-menu_links_left">
                         <div className="colorBlue__navbar-menu_links_logo">
-                            <RiMoonFill/>
+                            <RiMoonFill />
                         </div>
                         <a href="#">Night Mode</a>
                     </div>
@@ -88,23 +89,40 @@ const SlideDrawer = (props) => {
 
 const Navbar = () => {
     const [toggleMenu, setToggleMenu] = useState(false);
-    
+    const [toggleSearch, setToggleSearch] = useState(false);
+    {/* State for media query*/ }
+    const mediaBreak = '550px'
+    const [matches, setMatches] = useState(
+        window.matchMedia(`(max-width: ${mediaBreak})`).matches
+    )
+    {/* Set media query listener*/ }
+    useEffect(() => {
+        window
+            .matchMedia(`(max-width: ${mediaBreak})`)
+            .addEventListener('change', e => setMatches(e.matches));
+    }, []);
+    {/* Allow for searchbar toggle -- set width to '100%'  if viewport is larger than mediaBreak(550px) */ }
+    const searchBarToggleStyle = {
+        overflow: 'hidden',
+        width: matches ? toggleSearch ? '100%' : '0%' : '100%',
+        transition: "width 500ms ease-out"
+    }
+
     return (
-        
         <div className='colorBlue__navbar'>
             {/* Logo */}
             <div className='colorBlue__navbar-links_logo'>
-                <img src={ logo } alt="logo" />
+                <img src={logo} alt="logo" />
             </div>
-            
+
             {/* Search Bar */}
             <div className='colorBlue__navbar-search'>
-                <form action="/" method='get' className='colorBlue__navbar-search_form'>
+                <form action="/" method='get' className='colorBlue__navbar-search_form' style={searchBarToggleStyle}>
                     <label htmlFor="search-bar"><span className="hidden"></span></label>
                     <input type="text" readOnly name="s" id="search-bar" placeholder='Search The Blue...' value="" />
                 </form>
             </div>
-            
+
             {/* Links */}
             <div className='colorBlue__navbar-links'>
                 <div className='colorBlue__navbar-links_container'>
@@ -124,41 +142,44 @@ const Navbar = () => {
             {/* Buttons - Search*/}
             <div className='colorBlue__navbar-searchicon_border'>
                 <div className='colorBlue__navbar-searchicon'>
-                    <RiSearchLine color="#000000" size={25} /* onClick={() => setToggleSearch(true)}*/ />    
+                    {toggleSearch
+                        ? <RiSearchLine color="#000000" size={25} onClick={() => setToggleSearch(false)} />
+                        : <RiSearchLine color="#000000" size={25} onClick={() => setToggleSearch(true)} />
+                    }
                 </div>
             </div>
-            
+
             {/* Buttons - Menu*/}
             <div className='colorBlue__navbar-menuicon_border'>
                 <div className='colorBlue__navbar-menu'>
                     {toggleMenu
-                    ? <RiCloseLine color="#000000" size={25} onClick={() => setToggleMenu(false)} />
-                    : <RiMenuFill color="#000000" size={25} onClick={() => setToggleMenu(true)} />
-                    }  
+                        ? <RiCloseLine color="#000000" size={25} onClick={() => setToggleMenu(false)} />
+                        : <RiMenuFill color="#000000" size={25} onClick={() => setToggleMenu(true)} />
+                    }
                 </div>
             </div>
-            
+
             {/* Buttons - Profile*/}
             <div className='colorBlue__navbar-profileicon_border'>
                 <div className='colorBlue__navbar-profile'>
                     <RiUserSettingsLine color="#000000" size={25} /* onClick={() => setToggleMenu(true)} */ />
                 </div>
             </div>
-            
+
             {/* Buttons - Wallet*/}
             <div className='colorBlue__navbar-walleticon_border'>
                 <div className='colorBlue__navbar-wallet'>
                     <RiWalletLine color="#000000" size={25} /* onClick={() => setToggleMenu(true)} */ />
                 </div>
             </div>
-            
+
             {/* Menu Drawer */}
             <div>
-                <SlideDrawer show={toggleMenu}/>
-            </div>    
+                <SlideDrawer show={toggleMenu} />
+            </div>
         </div>
-        
-        
+
+
     );
 };
 

--- a/src/components/navbar/navbar.css
+++ b/src/components/navbar/navbar.css
@@ -23,7 +23,6 @@
 
 .colorBlue__navbar-links_logo {
     align-items: center;
-
     margin-right: 1rem;
 }
 
@@ -359,7 +358,6 @@
 @media screen and (max-width: 550px) {
     /* HIDE */
     .colorBlue__navbar-web3,
-    .colorBlue__navbar-search,
     .colorBlue__navbar-walleticon_border,
     .colorBlue__navbar-profileicon_border  {
         display: none;
@@ -386,6 +384,9 @@
     }
     .colorBlue__navbar-menu_container-links-web3 {
         display: block;
+    }
+    .colorBlue__navbar-search{
+        justify-content:flex-end;
     }
     
 }


### PR DESCRIPTION
### Issue:

Search bar does not work on mobile https://github.com/d1joseph/RaffleNFT/issues/6

### Description:
When viewed on devices with a screen width lesser than 600 px, when clicked, the responsive search button does nothing because:

it's missing code
media query isn't right
## Proposed Solution:
### Navbar.jsx
Implemented a _matches_ state that updates on an added _matchMedia eventListener_
Added state of _toggleSearch_. Functionality is the same as _toggleMenu_
Using _toggleSearch_ and matches states, adjust style of search bar at moblle screen.
### navbar.css
removed _.colorBlue__navbar-search_ from _/* Hide*/_ list (keep display:flex)
added _.colorBlue__navbar-search{justify-content:flex-end}_ to allow for search bar to expand from searchbar icon

![chrome-capture-2022-9-1 (1)](https://user-images.githubusercontent.com/96255825/193431868-20a241d3-d769-450c-8228-a37aee4a3c82.gif)
